### PR TITLE
Add docker setup

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,7 @@
+[runner]
+
+fastReruns = true
+
+[browser]
+
+gatherUsageStats = false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./requirements.txt
+
+RUN pip install -U pip
+RUN pip install -r requirements.txt
+
+EXPOSE 8501

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ pip install -r requirements.txt
 ```
 
 > ##### :rocket: Fast forward
-> Alternatively, if you don't have a working python or conda installation, you can fork a repl at: https://replit.com/@UMCResearch/mie2022workshopstreamlit (requires registration).
+> Alternatively, if you don't have a working python, conda or docker installation, you can fork a repl at: https://replit.com/@UMCResearch/mie2022workshopstreamlit (requires registration).
 >
 > Repl.it is a browser-based environment for running python scripts without installing python locally. UMC has no affiliation to repl.it.
 > 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ Once installed, follow the instructions in [tutorial.md](tutorial.md) for a step
 
 Start by creating the python environment where all our dependencies will be installed.
 
+> ##### :whale2: Docker
+> 
+> We provide a docker setup for those who do not have conda installed but may have docker installed. 
+> 
+> To run the workshop in a docker environment simply run the following command:
+> ```
+> docker compose up
+> ```
+> This will build the image and start a webserver at http://localhost:8501. If you run using docker, you can skip the rest of this section.
+
 We recommend that you install the dependencies in a conda environment, which you can create and activate using the following commands:
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  app:
+    build: .
+    volumes:
+      - ./:/app
+    ports:
+      - 127.0.0.1:8501:8501
+    command: streamlit run /app/workshop.py --server.port 8501

--- a/src/tutorial.md
+++ b/src/tutorial.md
@@ -2,6 +2,16 @@
 
 Let's start by creating the python environment where all our dependencies will be installed.
 
+> ##### :whale2: Docker
+> 
+> We provide a docker setup for those who do not have conda installed but may have docker installed. 
+> 
+> To run the workshop in a docker environment simply run the following command:
+> ```
+> docker compose up
+> ```
+> This will build the image and start a webserver at http://localhost:8501. If you run using docker, you can skip the rest of this section.
+
 We recommend that you install the dependencies in a conda environment, which can create and activate using the following commands:
 
 ```

--- a/src/tutorial.md
+++ b/src/tutorial.md
@@ -26,7 +26,7 @@ pip install -r requirements.txt
 ```
 
 > ##### :rocket: Fast forward
-> Alternatively, if you don't have a working python or conda installation, you can fork a repl at: https://replit.com/@UMCResearch/mie2022workshopstreamlit (requires registration).
+> Alternatively, if you don't have a working python, conda or docker installation, you can fork a repl at: https://replit.com/@UMCResearch/mie2022workshopstreamlit (requires registration).
 >
 > Repl.it is a browser-based environment for running python scripts without installing it locally. UMC has no affiliation to repl.it.
 > 

--- a/tutorial.md
+++ b/tutorial.md
@@ -2,6 +2,16 @@
 
 Let's start by creating the python environment where all our dependencies will be installed.
 
+> ##### :whale2: Docker
+> 
+> We provide a docker setup for those who do not have conda installed but may have docker installed. 
+> 
+> To run the workshop in a docker environment simply run the following command:
+> ```
+> docker compose up
+> ```
+> This will build the image and start a webserver at http://localhost:8501. If you run using docker, you can skip the rest of this section.
+
 We recommend that you install the dependencies in a conda environment, which can create and activate using the following commands:
 
 ```

--- a/tutorial.md
+++ b/tutorial.md
@@ -26,7 +26,7 @@ pip install -r requirements.txt
 ```
 
 > ##### :rocket: Fast forward
-> Alternatively, if you don't have a working python or conda installation, you can fork a repl at: https://replit.com/@UMCResearch/mie2022workshopstreamlit (requires registration).
+> Alternatively, if you don't have a working python, conda or docker installation, you can fork a repl at: https://replit.com/@UMCResearch/mie2022workshopstreamlit (requires registration).
 >
 > Repl.it is a browser-based environment for running python scripts without installing it locally. UMC has no affiliation to repl.it.
 > 

--- a/workshop.py
+++ b/workshop.py
@@ -1,0 +1,1 @@
+# write your code here :)


### PR DESCRIPTION
Add docker setup files and instructions. It is highly likely that the attendees have docker installed because of their own infrastructure, it would be nice to give them a choice to use it.

The `Dockerfile` creates a local docker image based on the `python:3.9-slim` image and installs dependencies. `docker-compose.yml` file runs the image and mounts the current directory as a volume and runs the `workshop.py` as a streamlit app. I intend to use the `workshop.py` (which is currently just a placeholder) to write code during the workshop.